### PR TITLE
Progress Caching

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,4 +1,5 @@
 import {
+  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
@@ -18,7 +19,9 @@ import { useAppSelector } from './store'
 import { navigationSelector } from './reducers/navigation'
 import { basePath } from './App'
 import { InstallAppButton } from './components/InstallAppButton'
-import { bookOutline, flaskOutline, optionsOutline } from 'ionicons/icons'
+import { bookOutline, flaskOutline, optionsOutline, play } from 'ionicons/icons'
+import { lessonsSelector } from './reducers/lessons'
+import { getFirstNextLesson } from './service/lesson'
 
 const MenuEntry = ({
   title,
@@ -31,23 +34,29 @@ const MenuEntry = ({
   icon: string
   menu?: string
 }) => (
-  <IonMenuToggle autoHide={false} menu={menu}>
-    <IonItem
-      button
-      routerLink={path}
-      routerDirection="root"
-      detail={false}
-      lines="none"
-      className={location.pathname === path ? 'selected' : ''}
-    >
-      <IonIcon icon={icon} slot="start" />
-      <IonLabel>{title}</IonLabel>
-    </IonItem>
-  </IonMenuToggle>
+  <IonItem
+    button
+    routerLink={path}
+    routerDirection="root"
+    detail={false}
+    lines="none"
+    className={[location.pathname === path ? 'selected' : '', 'ion-margin-end'].join(' ')}
+    style={{
+      border: '1px solid var(--ion-color-dark)',
+      borderRadius: '.65em',
+      marginBottom: '0.5em',
+      marginLeft: '2px',
+    }}
+  >
+    <IonIcon icon={icon} slot="start" />
+    <IonLabel>{title}</IonLabel>
+  </IonItem>
 )
 
 export const Layout = ({ children }) => {
   const navigationState = useAppSelector(navigationSelector)
+  const lessonsState = useAppSelector(lessonsSelector)
+  const nextLesson = getFirstNextLesson(lessonsState)
 
   return (
     <>
@@ -63,12 +72,33 @@ export const Layout = ({ children }) => {
           </IonToolbar>
         </IonHeader>
         <IonContent className="ion-padding">
-          <IonList className="ion-margin-bottom">
-            <MenuEntry title="Lessons" path={basePath + 'lessons'} icon={bookOutline} />
-            <MenuEntry title="Preferences" path={basePath + 'preferences'} icon={optionsOutline} />
-            {/*<MenuEntry title="Test" path={basePath + 'test'} icon={flaskOutline} />*/}
-          </IonList>
-          <InstallAppButton />
+          <IonMenuToggle menu="left-menu" autoHide={false}>
+            {nextLesson && (
+              <IonButton
+                color="success"
+                routerLink={basePath + 'lessons/' + nextLesson.lessonId}
+                className="ion-padding-end ion-margin-bottom"
+                style={{
+                  width: '100%',
+                  paddingRight: '1em',
+                  paddingTop: '0.5em',
+                }}
+              >
+                <IonIcon slot="start" icon={play} />
+                <IonLabel>{nextLesson.text} Lesson</IonLabel>
+              </IonButton>
+            )}
+            <IonList style={{ marginBottom: '.5em' }}>
+              <MenuEntry title="Lessons" path={basePath + 'lessons'} icon={bookOutline} />
+              <MenuEntry
+                title="Preferences"
+                path={basePath + 'preferences'}
+                icon={optionsOutline}
+              />
+              {/*<MenuEntry title="Test" path={basePath + 'test'} icon={flaskOutline} />*/}
+            </IonList>
+            <InstallAppButton />
+          </IonMenuToggle>
         </IonContent>
       </IonMenu>
       <IonPage id="main-content">

--- a/src/components/Quizzes.tsx
+++ b/src/components/Quizzes.tsx
@@ -3,20 +3,34 @@ import { useEffect, useState } from 'react'
 import { IonProgressBar } from '@ionic/react'
 import { MultipleChoiceQuiz } from './MultipleChoiceQuiz'
 import { CongratsAnimation } from './CongratsAnimation'
+import { useAppDispatch, useAppSelector } from '../store'
+import { lessonsSelector, setCurrentQuiz } from '../reducers/lessons'
+import { saveLessonsToStorage } from '../storage/lessons'
+import { getLessonQuizIndex } from '../service/lesson'
 
 interface QuizzesProps {
   quizzes: IQuiz[]
+  currentQuiz?: number
   onQuizChange?: (index: number) => void
   onQuizzesFinish?: () => void
 }
 
 export const Quizzes = (props: QuizzesProps) => {
-  const [currentQuizIndex, setCurrentQuizIndex] = useState(0)
+  const dispatch = useAppDispatch()
+
+  const [currentQuizIndex, setCurrentQuizIndex] = useState(props?.currentQuiz ?? 0)
   const [showCongrats, setShowCongrats] = useState(false)
   const [isQuizzesDone, setIsQuizzesDone] = useState(false)
 
+  const setQuizNumber = (index: number) => {
+    if (index >= 0 && index < props.quizzes.length) {
+      setCurrentQuizIndex(index)
+      dispatch(setCurrentQuiz(index))
+    }
+  }
+
   useEffect(() => {
-    setCurrentQuizIndex(0) // set to props.quizzes.length - 1 to test
+    setQuizNumber(props.currentQuiz ?? 0)
     setShowCongrats(false)
     setIsQuizzesDone(false)
   }, [])
@@ -34,7 +48,7 @@ export const Quizzes = (props: QuizzesProps) => {
     } else if (currentQuizIndex >= props.quizzes.length) {
       console.error('Invalid quiz index')
     } else {
-      setCurrentQuizIndex(prevIndex => prevIndex + 1)
+      setQuizNumber(currentQuizIndex + 1)
     }
   }
 

--- a/src/model/navigation.ts
+++ b/src/model/navigation.ts
@@ -1,4 +1,0 @@
-export interface NavigationState {
-  title: string
-  // TODO: current lesson & current quiz + continue button
-}

--- a/src/model/preferences.ts
+++ b/src/model/preferences.ts
@@ -1,4 +1,0 @@
-export interface Preferences {
-  darkMode: boolean
-  isAppInstalled: boolean
-}

--- a/src/model/states.ts
+++ b/src/model/states.ts
@@ -1,0 +1,40 @@
+/**
+ * @file states.ts
+ * @description This file contains the types and interfaces for the application state (Redux store).
+ */
+
+import { ILesson } from './lesson'
+import { IQuiz } from './quiz'
+
+export interface NavigationState {
+  title: string
+}
+
+export interface Preferences {
+  darkMode: boolean
+  isAppInstalled: boolean
+}
+
+export enum LessonStatus {
+  LEARNING,
+  QUIZ,
+  DONE,
+}
+
+export interface LessonState {
+  lesson: ILesson
+  quizzes: IQuiz[]
+  status: LessonStatus
+  currentQuiz?: number // index of the current quiz or undefined if there are no quizzes
+}
+
+export interface LessonsState {
+  lessons: LessonState[]
+  currentLesson?: number // index of the current lesson or undefined if there are no lessons
+}
+
+export interface LessonQuizIndex {
+  lessonIndex?: number
+  quizIndex?: number
+  completed?: boolean
+}

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -1,74 +1,54 @@
-import {
-  IonButton,
-  IonContent,
-  IonIcon,
-  IonItem,
-  IonItemDivider,
-  IonLabel,
-  IonList,
-} from '@ionic/react'
+import { IonButton, IonContent, IonItemDivider } from '@ionic/react'
 import { useAppDispatch, useAppSelector } from '../store'
 import { useEffect, useState } from 'react'
 import { setCurrentTab } from '../reducers/navigation'
 import { ILesson } from '../model/lesson'
 import { getLesson, getNextLesson } from '../service/lesson'
 import { LearnLesson } from '../components/LearnLesson'
-import { generateQuizzes } from '../service/quiz'
 import { Quizzes } from '../components/Quizzes'
 import { useParams } from 'react-router'
 import { IQuiz, QuizDataType } from '../model/quiz'
 import { WordCard } from '../components/WordCard'
 import { basePath } from '../App'
-
-enum LessonStatus {
-  LEARNING,
-  QUIZ,
-  DONE,
-}
+import { lessonsSelector, setCurrentLesson, setLessonStatus } from '../reducers/lessons'
+import { saveLessonsToStorage } from '../storage/lessons'
+import { LessonStatus } from '../model/states'
 
 export const LessonPage = ({ history }) => {
   const dispatch = useAppDispatch()
   const params = useParams<{ id: string }>()
   const id = params.id
-  const [lesson, setLesson] = useState<ILesson | undefined>()
-  const [quizzes, setQuizzes] = useState<IQuiz[]>([])
-  const [status, setStatus] = useState<LessonStatus>(LessonStatus.LEARNING)
+  const lessonsState = useAppSelector(lessonsSelector)
+  const lessonState = getLesson(lessonsState, id)
+  const lesson: ILesson = lessonState?.lesson
+  const status = lessonState?.status || LessonStatus.LEARNING
+  const quizzes: IQuiz[] = lessonState?.quizzes
+  const currentQuiz = lessonState?.currentQuiz
+
   const [hoveredIndex, setHoveredIndex] = useState<number>(-1)
 
   useEffect(() => {
     dispatch(setCurrentTab({ title: 'Lesson ' + id }))
-    // Fetch lessons from the API or local storage
-    getLesson(id)
-      .then(lesson => {
-        setLesson(lesson)
-        const quizzes = generateQuizzes(lesson)
-        console.log('Quizzes: ', quizzes)
-        setQuizzes(quizzes)
-        setStatus(LessonStatus.LEARNING)
-      })
-      .catch(err => {
-        alert('Error fetching lessons. DB may be not available')
-      })
-    // reset status to learning
+    dispatch(setCurrentLesson(id))
   }, [params.id])
 
   const startQuiz = () => {
-    setStatus(LessonStatus.QUIZ)
+    dispatch(setLessonStatus({ lessonId: id, status: LessonStatus.QUIZ }))
+  }
+
+  const onQuizFinish = async () => {
+    dispatch(setLessonStatus({ lessonId: id, status: LessonStatus.DONE }))
+    await saveLessonsToStorage(lessonsState)
   }
 
   const continueLearning = () => {
-    getNextLesson(id)
-      .then(nextLesson => {
-        if (nextLesson) {
-          history.push(basePath + 'lessons/' + nextLesson.id)
-        } else {
-          // go to lessons page. no next lesson available
-          history.push(basePath + 'lessons')
-        }
-      })
-      .catch(err => {
-        // go to lessons page. no next lesson available
-      })
+    const nextLessonState = getNextLesson(lessonsState, id)
+    if (nextLessonState) {
+      history.push(basePath + 'lessons/' + nextLessonState.lesson.id)
+    } else {
+      // go to lessons page. no next lesson available
+      history.push(basePath + 'lessons')
+    }
   }
 
   return (
@@ -95,7 +75,7 @@ export const LessonPage = ({ history }) => {
       )}
       {status === LessonStatus.QUIZ && (
         <>
-          <Quizzes quizzes={quizzes} onQuizzesFinish={() => setStatus(LessonStatus.DONE)} />
+          <Quizzes currentQuiz={currentQuiz} quizzes={quizzes} onQuizzesFinish={onQuizFinish} />
         </>
       )}
       {status === LessonStatus.DONE && (

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -1,23 +1,33 @@
 import { useAppDispatch, useAppSelector } from '../store'
 import { preferencesSelector, setPreferences } from '../reducers/preferences'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { setCurrentTab } from '../reducers/navigation'
 import {
+  IonButton,
   IonContent,
+  IonIcon,
   IonItem,
   IonLabel,
   IonList,
   IonListHeader,
+  IonPopover,
   IonRange,
   IonToggle,
 } from '@ionic/react'
 import { useDarkMode } from '../hooks/useDarkMode'
 import { savePreferencesToStorage } from '../storage/preferences'
+import { trashBinOutline, trashOutline } from 'ionicons/icons'
+import { clearLessonsFromStorage } from '../storage/lessons'
+import { getLessons } from '../service/lesson'
+import { setLessons, setLessonsWithQuizzes } from '../reducers/lessons'
 
 export const Preferences = () => {
   const dispatch = useAppDispatch()
   const preferences = useAppSelector(preferencesSelector)
   const { isDarkMode, toggleDarkMode } = useDarkMode()
+
+  const popoverRef = useRef<HTMLIonPopoverElement>(null)
+  const [isClearDataPopoverOpen, setIsClearDataPopoverOpen] = useState(false)
 
   useEffect(() => {
     dispatch(setCurrentTab({ title: 'Preferences' }))
@@ -39,6 +49,19 @@ export const Preferences = () => {
     savePreferencesToStorage(newPreferences).then(r => console.log('Saved preferences'))
   }
 
+  const clearData = async () => {
+    dispatch(setLessons({ lessons: [] }))
+    await clearLessonsFromStorage()
+    setIsClearDataPopoverOpen(false)
+    getLessons()
+      .then(lessons => {
+        dispatch(setLessonsWithQuizzes(lessons))
+      })
+      .catch(err => {
+        console.error('Error fetching lessons', err)
+      })
+  }
+
   return (
     <IonContent className="ion-padding">
       <IonListHeader style={{ fontSize: '1.5em' }}> Aspect </IonListHeader>
@@ -51,6 +74,52 @@ export const Preferences = () => {
           >
             Dark Mode
           </IonToggle>
+        </IonItem>
+      </IonList>
+      <IonListHeader style={{ fontSize: '1.5em' }}> Data </IonListHeader>
+      <IonList inset>
+        <IonItem>
+          <IonLabel id="clear-label" slot="start">
+            Clear progress
+          </IonLabel>
+          <IonPopover trigger="clear-label" triggerAction="click">
+            <IonContent className="ion-padding">
+              Useful in case of bugs or if you want to reset the app. All the progress will be lost.
+            </IonContent>
+          </IonPopover>
+          <IonButton
+            id="clear-button"
+            onClick={() => setIsClearDataPopoverOpen(true)}
+            slot="end"
+            color="danger"
+            style={{
+              width: '2.5em',
+              height: '2.5em',
+              transform: 'scale(1.2)',
+            }}
+          >
+            <IonIcon
+              slot="icon-only"
+              icon={trashOutline}
+              style={{
+                fontSize: '2em',
+              }}
+            />
+          </IonButton>
+          <IonPopover
+            trigger="clear-button"
+            ref={popoverRef}
+            isOpen={isClearDataPopoverOpen}
+            onDidDismiss={() => setIsClearDataPopoverOpen(false)}
+          >
+            <IonContent className="ion-padding">
+              <h3>Are you sure you want to clear all your progress?</h3>
+              <p>This will remove all your learned words and reset the app to its initial state.</p>
+              <IonButton color="danger" onClick={clearData} style={{ width: '100%' }}>
+                Yes
+              </IonButton>
+            </IonContent>
+          </IonPopover>
         </IonItem>
       </IonList>
     </IonContent>

--- a/src/reducers/lessons.ts
+++ b/src/reducers/lessons.ts
@@ -1,0 +1,55 @@
+import { LessonsState, LessonStatus } from '../model/states'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from '../store'
+import { ILesson } from '../model/lesson'
+import { updateLessonsState } from '../service/lesson'
+
+interface LessonStatusPayload {
+  lessonId: string
+  status: LessonStatus
+}
+
+const initialState = {
+  lessons: [],
+} as LessonsState
+
+const navigationSlice = createSlice({
+  name: 'lessons',
+  initialState,
+  reducers: {
+    setLessons: (state, action: PayloadAction<LessonsState>) => {
+      if (!action.payload) return
+      state.lessons = action.payload.lessons
+      state.currentLesson = action.payload.currentLesson
+    },
+    setLessonsWithQuizzes: (state, action: PayloadAction<ILesson[]>) => {
+      if (!action.payload) return
+      return updateLessonsState(state, action.payload)
+    },
+    setCurrentLesson: (state, action: PayloadAction<string>) => {
+      const lessonId = action.payload
+      const lessonIndex = state.lessons.findIndex(lesson => lesson.lesson.id === lessonId)
+      state.currentLesson = lessonIndex
+    },
+    setLessonStatus: (state, action: PayloadAction<LessonStatusPayload>) => {
+      const lessonId = action.payload.lessonId
+      const lessonIndex = state.lessons.findIndex(lesson => lesson.lesson.id === lessonId)
+      if (lessonIndex < 0) return
+      state.lessons[lessonIndex].status = action.payload.status
+    },
+    setCurrentQuiz: (state, action: PayloadAction<number | undefined>) => {
+      if (state.currentLesson === undefined) return
+      state.lessons[state.currentLesson].currentQuiz = action.payload
+    },
+  },
+})
+
+export const {
+  setLessons,
+  setLessonsWithQuizzes,
+  setCurrentLesson,
+  setLessonStatus,
+  setCurrentQuiz,
+} = navigationSlice.actions
+export default navigationSlice.reducer
+export const lessonsSelector = (state: RootState): LessonsState => state.lessons

--- a/src/reducers/navigation.ts
+++ b/src/reducers/navigation.ts
@@ -1,4 +1,4 @@
-import { NavigationState } from '../model/navigation'
+import { NavigationState } from '../model/states'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '../store'
 

--- a/src/reducers/preferences.ts
+++ b/src/reducers/preferences.ts
@@ -1,6 +1,6 @@
-import { Preferences } from '../model/preferences'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '../store'
+import { Preferences } from '../model/states'
 
 export const initialPreferences = {
   darkMode: false,

--- a/src/service/lesson.ts
+++ b/src/service/lesson.ts
@@ -1,7 +1,13 @@
 import { ILesson } from '../model/lesson'
-import { IMultipleChoiceQuiz } from '../model/quiz'
+import { LessonQuizIndex, LessonsState, LessonState, LessonStatus } from '../model/states'
+import { generateQuizzes } from './quiz'
 
 const API_URL = 'https://masteris4x4.github.io/SpickAppGithubAPI/data'
+
+interface FirstNextLesson {
+  lessonId: string
+  text: 'Start' | 'Resume'
+}
 
 export async function getLessons(): Promise<ILesson[]> {
   const response = await fetch(`${API_URL}/lessons.json`)
@@ -16,36 +22,77 @@ export async function getLessons(): Promise<ILesson[]> {
   }
 }
 
-export async function getLesson(id: string): Promise<ILesson> {
-  const response = await fetch(`${API_URL}/lessons.json`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch lesson')
-  }
-  try {
-    const lessons: ILesson[] = await response.json()
-    console.info('Fetched lessons: ', lessons)
-    return lessons.find(lesson => lesson.id === id) || null
-  } catch (error) {
-    console.error('Error parsing lesson data: ', error)
-    throw new Error('Failed to parse lesson data. JSON format is incorrect.')
+export const getLesson = (state: LessonsState, lessonId: string): LessonState | undefined => {
+  const lessonIndex = state.lessons.findIndex(lesson => lesson.lesson.id === lessonId)
+  if (lessonIndex < 0) return
+  return state.lessons[lessonIndex]
+}
+
+export const getNextLesson = (state: LessonsState, lessonId: string): LessonState | undefined => {
+  let lessonIndex = state.lessons.findIndex(lesson => lesson.lesson.id === lessonId)
+  if (lessonIndex < 0) return
+  let nextLessonIndex = lessonIndex + 1
+  while (
+    nextLessonIndex < state.lessons.length &&
+    state.lessons[nextLessonIndex].status === LessonStatus.DONE
+  )
+    nextLessonIndex++
+  return state.lessons[nextLessonIndex]
+}
+
+export const getLessonQuizIndex = (state: LessonsState): LessonQuizIndex => {
+  const currentLesson = state.currentLesson
+  if (!currentLesson) return {}
+  const lesson = state.lessons[currentLesson]
+  return {
+    lessonIndex: currentLesson,
+    quizIndex: lesson?.currentQuiz,
+    completed: lesson?.status === LessonStatus.DONE,
   }
 }
 
-export async function getNextLesson(id: string): Promise<ILesson | undefined> {
-  const response = await fetch(`${API_URL}/lessons.json`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch lesson')
+export const getFirstNextLesson = (state: LessonsState): FirstNextLesson | undefined => {
+  if (!state.lessons || state.lessons.length === 0) return
+  const lesson = state.lessons.find(l => l.status !== LessonStatus.DONE)
+  if (!lesson) return
+  return {
+    lessonId: lesson.lesson.id,
+    text: lesson.status === LessonStatus.LEARNING ? 'Start' : 'Resume',
   }
-  try {
-    const lessons: ILesson[] = await response.json()
-    console.info('Fetched lessons: ', lessons)
-    const index = lessons.findIndex(lesson => lesson.id === id)
-    if (index < 0 || index + 1 >= lessons.length) {
-      return undefined
+}
+
+export const updateLessonsState = (
+  currentLessons: LessonsState,
+  lessons: ILesson[],
+): LessonsState => {
+  const newLessons = lessons.filter(
+    lesson => !currentLessons.lessons.find(l => l.lesson.id === lesson.id),
+  )
+  const newLessonsWithQuizzes: LessonState[] = newLessons.map(lesson => ({
+    lesson,
+    quizzes: generateQuizzes(lesson),
+    status: LessonStatus.LEARNING, // new lessons start in learning state
+    currentQuiz: undefined,
+  }))
+  const oldLessons = currentLessons.lessons.filter(lesson =>
+    lessons.find(l => l.id === lesson.lesson.id),
+  )
+  const updatedLessons = oldLessons.map(lesson => {
+    const newLesson = lessons.find(l => l.id === lesson.lesson.id)
+    if (JSON.stringify(lesson.lesson) === JSON.stringify(newLesson)) {
+      return lesson
     }
-    return lessons[index + 1]
-  } catch (error) {
-    console.error('Error parsing lesson data: ', error)
-    throw new Error('Failed to parse lesson data. JSON format is incorrect.')
-  }
+    return {
+      lesson: newLesson,
+      quizzes: generateQuizzes(newLesson),
+      status: LessonStatus.LEARNING, // reset status to learning for updated lessons
+      currentQuiz: undefined,
+    }
+  })
+  currentLessons.lessons = [...updatedLessons, ...newLessonsWithQuizzes].sort((a, b) => {
+    if (a.lesson.id < b.lesson.id) return -1
+    if (a.lesson.id > b.lesson.id) return 1
+    return 0
+  })
+  return currentLessons
 }

--- a/src/storage/lessons.ts
+++ b/src/storage/lessons.ts
@@ -1,0 +1,18 @@
+import { Preferences } from '@capacitor/preferences'
+
+import { LessonsState } from '../model/states'
+
+export const getLessonsFromStorage = async (): Promise<LessonsState> => {
+  return await Preferences.get({ key: 'lessons' }).then(data => {
+    if (!data.value) throw new Error('Lessons not found')
+    return JSON.parse(data.value) as LessonsState
+  })
+}
+
+export const saveLessonsToStorage = async (data: any) => {
+  await Preferences.set({ key: 'lessons', value: JSON.stringify(data) })
+}
+
+export const clearLessonsFromStorage = async () => {
+  await Preferences.remove({ key: 'lessons' })
+}

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -1,5 +1,6 @@
 import { Preferences } from '@capacitor/preferences'
-import { Preferences as PreferencesModel } from '../model/preferences'
+
+import { Preferences as PreferencesModel } from '../model/states'
 
 export const getPreferencesFromStorage = async (): Promise<PreferencesModel> => {
   return await Preferences.get({ key: 'preferences' }).then(data => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,11 +2,13 @@ import { configureStore } from '@reduxjs/toolkit'
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import navigation from './reducers/navigation'
 import preferences from './reducers/preferences'
+import lessons from './reducers/lessons'
 
 export const store = configureStore({
   reducer: {
     navigation,
     preferences,
+    lessons,
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({


### PR DESCRIPTION
- load and save lessons to local storage whenever they change
- algorithm to merge existing quizes state (already generated quizes & their progress) to the new ones on the server
- save current lesson and current quiz
- continue lesson button
- lesson state is persisted (you get the last quiz if you started the quizes, and the glossary if you finished the quiz)
- redesign the menu to be compliant with the new button
- use local storage for getting next lesson rather than api
- button to clear data. It's better to allow the user to do it in case of bugs.

TODO:
- algorithm to merge quizes when new words come from the API
- for full offline support, resource cacher